### PR TITLE
Fix object discovery runtime view

### DIFF
--- a/__tests__/bacnet_client.test.js
+++ b/__tests__/bacnet_client.test.js
@@ -90,7 +90,8 @@ describe('BacnetClient', () => {
             upsertDeviceState: jest.fn().mockResolvedValue(undefined),
             saveObjectTelemetry: jest.fn().mockResolvedValue(undefined),
             recordPollHistory: jest.fn().mockResolvedValue(undefined),
-            listDeviceStates: jest.fn().mockResolvedValue([])
+            listDeviceStates: jest.fn().mockResolvedValue([]),
+            listObjectStates: jest.fn().mockResolvedValue([])
         };
         bacnetConfig = new MockBacnetConfig();
         jest.resetModules();
@@ -451,6 +452,8 @@ describe('BacnetClient', () => {
         await expect(client.writeProperty('a', { type: 1, instance: 1 }, 85, 1)).rejects.toThrow('write error');
         expect(logger.log).toHaveBeenCalledWith('error', expect.stringContaining('[BACnet Write] Error writing property: Error: write error'));
         await expect(client.listRuntimeStates()).resolves.toEqual([]);
+        await expect(client.listRuntimeObjectStates(114)).resolves.toEqual([]);
+        expect(runtimeState.listObjectStates).toHaveBeenCalledWith('114');
         expect(client.getStatus()).toEqual(expect.objectContaining({
             configuredDevices: client.deviceConfigs.size,
             avgPollDurationMs: expect.any(Number)

--- a/__tests__/openapi.test.js
+++ b/__tests__/openapi.test.js
@@ -1,0 +1,34 @@
+const YAML = require('yamljs');
+
+describe('OpenAPI regression coverage', () => {
+    let spec;
+
+    beforeAll(() => {
+        spec = YAML.load('openapi.yaml');
+    });
+
+    test('defines JWT bearer auth so Swagger UI can authorize protected routes', () => {
+        expect(spec.components.securitySchemes.bearerAuth).toEqual({
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT'
+        });
+        expect(spec.security).toEqual([{ bearerAuth: [] }]);
+    });
+
+    test('documents runtime object state endpoint and decoded object values', () => {
+        const pathSpec = spec.paths['/api/bacnet/runtime-objects/{deviceId}'];
+
+        expect(pathSpec.get.summary).toContain('runtime BACnet object state');
+        expect(pathSpec.get.parameters).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'deviceId', in: 'path', required: true })
+        ]));
+        expect(pathSpec.get.responses['200'].content['application/json'].schema.items.$ref)
+            .toBe('#/components/schemas/RuntimeObjectState');
+        expect(spec.components.schemas.RuntimeObjectState.properties.value.oneOf)
+            .toEqual(expect.arrayContaining([
+                expect.objectContaining({ type: 'number' }),
+                expect.objectContaining({ type: 'boolean' })
+            ]));
+    });
+});

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -81,6 +81,7 @@ describe('Server helper methods', () => {
         expect(expressApp.post).toHaveBeenCalledWith('/auth/login', expect.any(Function), expect.any(Function));
         expect(expressApp.get).toHaveBeenCalledWith('/health', expect.any(Function));
         expect(expressApp.get).toHaveBeenCalledWith('/metrics', expect.any(Function));
+        expect(expressApp.get).toHaveBeenCalledWith('/api/bacnet/runtime-objects/:deviceId', expect.any(Function), expect.any(Function), expect.any(Function));
         expect(expressApp.put).toHaveBeenCalledWith('/api/bacnet/write', expect.any(Function), expect.any(Function), expect.any(Function));
         expect(expressApp.listen).toHaveBeenCalledWith(8082, expect.any(Function));
         expressApp.listen.mock.calls[0][1]();
@@ -246,6 +247,46 @@ describe('Server helper methods', () => {
 
         expect(res.statusCode).toBe(500);
         expect(res.payload.message).toBe('Failed to fetch runtime states');
+    });
+
+    test('listRuntimeObjects returns persisted object states for a device', async () => {
+        const server = Object.create(Server.prototype);
+        server.bacnetClient = {
+            listRuntimeObjectStates: jest.fn().mockResolvedValue([{ device_id: '114', object_key: '2_202', value: 21.5 }])
+        };
+        const res = createResponse();
+
+        await server._listRuntimeObjects({ params: { deviceId: '114' } }, res);
+
+        expect(server.bacnetClient.listRuntimeObjectStates).toHaveBeenCalledWith('114');
+        expect(res.payload).toEqual([{ device_id: '114', object_key: '2_202', value: 21.5 }]);
+    });
+
+    test('listRuntimeObjects rejects missing device id without querying runtime state', async () => {
+        const server = Object.create(Server.prototype);
+        server.bacnetClient = {
+            listRuntimeObjectStates: jest.fn()
+        };
+        const res = createResponse();
+
+        await server._listRuntimeObjects({ params: { deviceId: '' } }, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.payload.message).toBe('deviceId is required');
+        expect(server.bacnetClient.listRuntimeObjectStates).not.toHaveBeenCalled();
+    });
+
+    test('listRuntimeObjects returns 500 on object state failure', async () => {
+        const server = Object.create(Server.prototype);
+        server.bacnetClient = {
+            listRuntimeObjectStates: jest.fn().mockRejectedValue(new Error('db down'))
+        };
+        const res = createResponse();
+
+        await server._listRuntimeObjects({ params: { deviceId: '114' } }, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.payload.message).toBe('Failed to fetch runtime object states');
     });
 
     test('configure polling rejects invalid payload', () => {

--- a/__tests__/web_admin.test.js
+++ b/__tests__/web_admin.test.js
@@ -82,7 +82,8 @@ describe('web admin app', () => {
             WhoisPanel: expect.any(Object),
             DeviceScan: expect.any(Object),
             ConfiguredDevices: expect.any(Object),
-            RuntimeDevices: expect.any(Object)
+            RuntimeDevices: expect.any(Object),
+            RuntimeObjects: expect.any(Object)
         }));
     });
 
@@ -118,6 +119,28 @@ describe('web admin app', () => {
 
         expect(html).toContain('https://unpkg.com/vue@3/dist/vue.global.prod.js');
         expect(html).toContain("showView('runtime')");
+        expect(html).toContain("showView('runtimeObjects')");
         expect(html).toContain('id="runtime-devices-template"');
+        expect(html).toContain('id="runtime-objects-template"');
+    });
+
+    test('runtime objects view loads persisted object states through the new API', async () => {
+        const { context, exports } = loadAdminScript();
+        const RuntimeObjects = exports.appOptions.components.RuntimeObjects;
+        const component = {
+            ...RuntimeObjects.data(),
+            ...RuntimeObjects.methods
+        };
+        component.deviceId = 'Gree VRF/1';
+        context.axios.get.mockResolvedValue({
+            data: [{ device_id: 'Gree VRF/1', object_key: '2_202', value: 21.5 }]
+        });
+
+        await component.load();
+
+        expect(context.axios.get).toHaveBeenCalledWith('/api/bacnet/runtime-objects/Gree%20VRF%2F1');
+        expect(component.objects).toEqual([{ device_id: 'Gree VRF/1', object_key: '2_202', value: 21.5 }]);
+        expect(component.loaded).toBe(true);
+        expect(component.loading).toBe(false);
     });
 });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,7 +12,15 @@ servers:
         default: '8082' 
         description: Server port
 
+security:
+  - bearerAuth: []
+
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     DeviceScanRequest:
       type: object
@@ -86,6 +94,50 @@ components:
         description:
           type: string
           nullable: true
+    RuntimeObjectState:
+      type: object
+      properties:
+        device_id:
+          type: string
+          example: "114"
+        object_key:
+          type: string
+          example: "2_202"
+        object_name:
+          type: string
+          nullable: true
+          example: Indoor Temperature
+        value:
+          nullable: true
+          description: Decoded current object value from the runtime database.
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean
+            - type: object
+            - type: array
+              items: {}
+        acquired_at:
+          type: integer
+          nullable: true
+          description: Unix epoch milliseconds when the BACnet value was acquired.
+        published_at:
+          type: integer
+          nullable: true
+          description: Unix epoch milliseconds when the value was published to MQTT.
+        freshness_ms:
+          type: integer
+          nullable: true
+        source_status:
+          type: string
+          nullable: true
+          example: fresh
+        poll_duration_ms:
+          type: integer
+          nullable: true
+        updated_at:
+          type: integer
+          description: Unix epoch milliseconds when the runtime row was last updated.
     WritePropertyRequest:
       type: object
       required:
@@ -263,6 +315,33 @@ paths:
                 type: array
                 items:
                   type: object
+
+  /api/bacnet/runtime-objects/{deviceId}:
+    get:
+      summary: List runtime BACnet object state for a device
+      description: Returns persisted object runtime values from SQLite for a configured BACnet device.
+      parameters:
+        - name: deviceId
+          in: path
+          required: true
+          description: The configured BACnet device ID.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Runtime object state entries for the device.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuntimeObjectState'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/bacnet/write:
     put:

--- a/src/bacnet_client.js
+++ b/src/bacnet_client.js
@@ -555,6 +555,10 @@ class BacnetClient extends EventEmitter {
         return this.runtimeState.listDeviceStates();
     }
 
+    async listRuntimeObjectStates(deviceId) {
+        return this.runtimeState.listObjectStates(deviceId.toString());
+    }
+
     getStatus() {
         const avgPollDurationMs = this.metrics.totalPolls > 0
             ? this.metrics.totalPollDurationMs / this.metrics.totalPolls

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,7 @@ class Server {
         this.app.put('/api/bacnet/:deviceId/objects', apiLimiter, this._requireRole('viewer'), this._scanDevice.bind(this));
         this.app.get('/api/bacnet/configured', apiLimiter, this._requireRole('viewer'), this._listConfigured.bind(this));
         this.app.get('/api/bacnet/runtime', apiLimiter, this._requireRole('viewer'), this._listRuntime.bind(this));
+        this.app.get('/api/bacnet/runtime-objects/:deviceId', apiLimiter, this._requireRole('viewer'), this._listRuntimeObjects.bind(this));
         this.app.put('/api/bacnet/:deviceId/config', apiLimiter, this._requireRole('admin'), this._configurePolling.bind(this));
         this.app.put('/api/bacnet/write', apiLimiter, this._requireRole('admin'), this._writeProperty.bind(this)); 
 
@@ -194,6 +195,20 @@ class Server {
         } catch (err) {
             logger.log('error', `[API] Failed to fetch runtime states: ${err}`);
             res.status(500).send({ status: 'error', message: 'Failed to fetch runtime states' });
+        }
+    }
+
+    async _listRuntimeObjects(req, res) {
+        const { deviceId } = req.params || {};
+        if (deviceId === undefined || deviceId === '') {
+            return res.status(400).send({ status: 'error', message: 'deviceId is required' });
+        }
+        try {
+            const states = await this.bacnetClient.listRuntimeObjectStates(deviceId);
+            res.send(states);
+        } catch (err) {
+            logger.log('error', `[API] Failed to fetch runtime object states for ${deviceId}: ${err}`);
+            res.status(500).send({ status: 'error', message: 'Failed to fetch runtime object states' });
         }
     }
 

--- a/web/admin.css
+++ b/web/admin.css
@@ -196,6 +196,11 @@ body {
     border-color: rgba(148, 163, 184, 0.1);
 }
 
+.runtime-object-table td {
+    max-width: 260px;
+    overflow-wrap: anywhere;
+}
+
 .modal-backdrop {
     position: fixed;
     inset: 0;

--- a/web/admin.js
+++ b/web/admin.js
@@ -342,13 +342,69 @@ const RuntimeDevices = {
     }
 };
 
+const RuntimeObjects = {
+    template: '#runtime-objects-template',
+    components: { Spinner },
+    data() {
+        return {
+            loading: false,
+            loaded: false,
+            deviceId: '',
+            objects: [],
+            error: null
+        };
+    },
+    methods: {
+        formatTimestamp(value) {
+            if (!value) {
+                return '-';
+            }
+            return new Date(value).toLocaleString();
+        },
+        formatDuration(value) {
+            if (!value) {
+                return '-';
+            }
+            return `${value} ms`;
+        },
+        formatValue(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+            if (typeof value === 'object') {
+                return JSON.stringify(value);
+            }
+            return String(value);
+        },
+        async load() {
+            if (!this.deviceId) {
+                return;
+            }
+            this.loading = true;
+            this.loaded = false;
+            this.error = null;
+            try {
+                const response = await axios.get(`/api/bacnet/runtime-objects/${encodeURIComponent(this.deviceId)}`);
+                this.objects = response.data || [];
+            } catch (error) {
+                this.objects = [];
+                this.error = extractErrorMessage(error, 'Failed to load runtime object state');
+            } finally {
+                this.loaded = true;
+                this.loading = false;
+            }
+        }
+    }
+};
+
 createApp({
     components: {
         Spinner,
         WhoisPanel,
         DeviceScan,
         ConfiguredDevices,
-        RuntimeDevices
+        RuntimeDevices,
+        RuntimeObjects
     },
     data() {
         return {

--- a/web/index.html
+++ b/web/index.html
@@ -82,6 +82,7 @@
                     <button class="btn nav-btn" :class="{ active: state === 'objects' }" @click="showView('objects')">Object Scan</button>
                     <button class="btn nav-btn" :class="{ active: state === 'configured' }" @click="showView('configured')">Configured</button>
                     <button class="btn nav-btn" :class="{ active: state === 'runtime' }" @click="showView('runtime')">Runtime</button>
+                    <button class="btn nav-btn" :class="{ active: state === 'runtimeObjects' }" @click="showView('runtimeObjects')">Runtime Objects</button>
                 </nav>
             </div>
         </header>
@@ -91,6 +92,7 @@
             <device-scan v-if="state === 'objects'" :can-write="canWrite"></device-scan>
             <configured-devices v-if="state === 'configured'"></configured-devices>
             <runtime-devices v-if="state === 'runtime'"></runtime-devices>
+            <runtime-objects v-if="state === 'runtimeObjects'"></runtime-objects>
         </main>
 
         <div v-if="changePasswordModal" class="modal-backdrop">
@@ -301,6 +303,58 @@
             </tbody>
         </table>
         <div v-else-if="!loading" class="empty-state">No runtime state available.</div>
+    </section>
+</script>
+
+<script type="text/x-template" id="runtime-objects-template">
+    <section class="panel">
+        <div class="panel-header">
+            <div>
+                <div class="eyebrow">Runtime</div>
+                <h2 class="panel-title">Object Runtime State</h2>
+            </div>
+            <button class="btn btn-primary" @click="load" :disabled="loading || !deviceId">Refresh</button>
+        </div>
+        <p class="panel-copy">Live persisted object values from SQLite for one configured BACnet device.</p>
+
+        <form class="form-grid" @submit.prevent="load">
+            <div class="form-group">
+                <label for="runtimeObjectDeviceId">Device ID</label>
+                <input id="runtimeObjectDeviceId" v-model="deviceId" class="form-control">
+            </div>
+            <div class="form-group action-group">
+                <button class="btn btn-primary" :disabled="loading || !deviceId">Load Objects</button>
+            </div>
+        </form>
+
+        <div v-if="loading">
+            <spinner></spinner>
+        </div>
+        <div v-if="error" class="alert alert-danger">{{ error }}</div>
+        <table class="table table-dark mt-3 runtime-object-table" v-if="!loading && objects.length">
+            <thead>
+            <tr>
+                <th>Object Key</th>
+                <th>Name</th>
+                <th>Current Value</th>
+                <th>Freshness</th>
+                <th>Source</th>
+                <th>Last Update</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="object in objects" :key="object.device_id + '-' + object.object_key">
+                <td>{{ object.object_key }}</td>
+                <td>{{ object.object_name || '-' }}</td>
+                <td>{{ formatValue(object.value) }}</td>
+                <td>{{ formatDuration(object.freshness_ms) }}</td>
+                <td>{{ object.source_status || '-' }}</td>
+                <td>{{ formatTimestamp(object.updated_at || object.acquired_at) }}</td>
+            </tr>
+            </tbody>
+        </table>
+        <div v-else-if="!loading && loaded" class="empty-state">No runtime object state available for this device.</div>
+        <div v-else-if="!loading" class="empty-state">Enter a device ID to load object state.</div>
     </section>
 </script>
 


### PR DESCRIPTION
## Summary

- Add an authenticated runtime object-state API for configured BACnet devices.
- Add a Runtime Objects admin UI view backed by persisted SQLite object state.
- Document JWT bearer auth and the new runtime object endpoint in OpenAPI.

## Tests

- npm test -- --runInBand

Closes #50