### PR TITLE
Object discovery

### DIFF
--- a/__tests__/bacnet_client.test.js
+++ b/__tests__/bacnet_client.test.js
@@ -1,6 +1,7 @@
 process.env.NODE_CONFIG_STRICT_MODE = '0';
 
 const mockReadPropertyMultiple = jest.fn();
+const mockReadProperty = jest.fn();
 const mockWriteProperty = jest.fn();
 const mockWhoIs = jest.fn();
 const mockScheduleJob = jest.fn();
@@ -10,6 +11,7 @@ jest.mock('bacstack', () => {
         const { EventEmitter } = require('events');
         const emitter = new EventEmitter();
         emitter.readPropertyMultiple = mockReadPropertyMultiple;
+        emitter.readProperty = mockReadProperty;
         emitter.writeProperty = mockWriteProperty;
         emitter.whoIs = mockWhoIs;
         return emitter;
@@ -116,6 +118,39 @@ describe('BacnetClient', () => {
         };
     }
 
+    function buildObjectListResponse(objects) {
+        return {
+            values: [{
+                values: [{
+                    value: objects.map((objectId) => ({ value: objectId }))
+                }]
+            }]
+        };
+    }
+
+    function buildReadPropertyResponse(value, arrayIndex) {
+        return {
+            property: { id: 76, index: arrayIndex },
+            values: [{ value }]
+        };
+    }
+
+    function buildFullObjectResponse(objectId, name) {
+        return {
+            values: [{
+                objectId,
+                values: [
+                    { id: 75, value: [{ value: objectId }] },
+                    { id: 77, value: [{ value: name }] },
+                    { id: 79, value: [{ value: objectId.type }] },
+                    { id: 28, value: [{ value: `${name} description` }] },
+                    { id: 117, value: [{ value: 'unit' }] },
+                    { id: 85, value: [{ value: 1 }] }
+                ]
+            }]
+        };
+    }
+
     function cleanup(client) {
         clearInterval(client.schedulerHandle);
     }
@@ -146,33 +181,16 @@ describe('BacnetClient', () => {
     });
 
     test('scanDevice returns mapped device objects on success', async () => {
+        mockReadProperty.mockImplementation((_addr, _objectId, _propertyId, options, cb) => {
+            cb(null, buildReadPropertyResponse(1, options.arrayIndex));
+        });
         mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
             const request = requestArray[0];
             if (request.objectId.type === 8) {
-                cb(null, {
-                    values: [{
-                        values: [{
-                            value: [
-                                { value: { type: 2, instance: 202 } }
-                            ]
-                        }]
-                    }]
-                });
+                cb(null, buildObjectListResponse([{ type: 2, instance: 202 }]));
                 return;
             }
-            cb(null, {
-                values: [{
-                    objectId: request.objectId,
-                    values: [
-                        { id: 75, value: [{ value: request.objectId }] },
-                        { id: 77, value: [{ value: 'Zone Temp' }] },
-                        { id: 79, value: [{ value: request.objectId.type }] },
-                        { id: 28, value: [{ value: 'Room temperature' }] },
-                        { id: 117, value: [{ value: 'degC' }] },
-                        { id: 85, value: [{ value: 22.3 }] }
-                    ]
-                }]
-            });
+            cb(null, buildFullObjectResponse(request.objectId, 'Zone Temp'));
         });
 
         const { BacnetClient } = require('../src/bacnet_client');
@@ -183,6 +201,55 @@ describe('BacnetClient', () => {
 
         expect(objects).toHaveLength(1);
         expect(objects[0].name).toBe('Zone Temp');
+        cleanup(client);
+    });
+
+    test('scanDevice falls back to indexed object list reads when the full list is an incomplete subset', async () => {
+        const allObjects = [
+            { type: 3, instance: 136195 },
+            { type: 19, instance: 136192 },
+            { type: 19, instance: 136193 },
+            { type: 19, instance: 136448 },
+            { type: 19, instance: 136449 }
+        ];
+        mockReadProperty.mockImplementation((_addr, _objectId, propertyId, options, cb) => {
+            expect(propertyId).toBe(76);
+            if (options.arrayIndex === 0) {
+                cb(null, buildReadPropertyResponse(allObjects.length, 0));
+                return;
+            }
+            cb(null, buildReadPropertyResponse(allObjects[options.arrayIndex - 1], options.arrayIndex));
+        });
+        mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
+            const request = requestArray[0];
+            if (request.objectId.type === 8) {
+                cb(null, buildObjectListResponse([allObjects[0], allObjects[3]]));
+                return;
+            }
+            cb(null, buildFullObjectResponse(request.objectId, `Object ${request.objectId.instance}`));
+        });
+
+        const { BacnetClient } = require('../src/bacnet_client');
+        const client = new BacnetClient({ runtimeState, bacnetConfig });
+        await client.ready;
+
+        const objects = await client.scanDevice({ address: '10.0.0.1', deviceId: 123 });
+
+        expect(objects.map((object) => object.objectId)).toEqual(allObjects);
+        expect(mockReadProperty).toHaveBeenCalledWith(
+            '10.0.0.1',
+            { type: 8, instance: 123 },
+            76,
+            expect.objectContaining({ arrayIndex: 0 }),
+            expect.any(Function)
+        );
+        expect(mockReadProperty).toHaveBeenCalledWith(
+            '10.0.0.1',
+            { type: 8, instance: 123 },
+            76,
+            expect.objectContaining({ arrayIndex: 5 }),
+            expect.any(Function)
+        );
         cleanup(client);
     });
 
@@ -417,6 +484,7 @@ describe('BacnetClient', () => {
         jest.spyOn(client, '_readObjectList').mockImplementation((_addr, _id, cb) => cb(null, {
             values: [{ values: [{ value: [{ value: { type: 2, instance: 1 } }] }] }]
         }));
+        jest.spyOn(client, '_readObjectListCount').mockResolvedValue(1);
         jest.spyOn(client, '_readObjectFull').mockRejectedValue(new Error('catastrophic read'));
 
         await expect(client.scanDevice({ address: '10.0.0.5', deviceId: 5 })).rejects.toThrow('catastrophic read');

--- a/__tests__/bacnet_client.test.js
+++ b/__tests__/bacnet_client.test.js
@@ -253,6 +253,47 @@ describe('BacnetClient', () => {
         cleanup(client);
     });
 
+    test('scanDevice keeps objects when optional full metadata reads fail', async () => {
+        const allObjects = [
+            { type: 5, instance: 136448 },
+            { type: 19, instance: 136449 }
+        ];
+        mockReadProperty.mockImplementation((_addr, _objectId, _propertyId, options, cb) => {
+            cb(null, buildReadPropertyResponse(allObjects.length, options.arrayIndex));
+        });
+        mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
+            const request = requestArray[0];
+            if (request.objectId.type === 8) {
+                cb(null, buildObjectListResponse(allObjects));
+                return;
+            }
+            const propertyIds = request.properties.map((property) => property.id);
+            if (request.objectId.type === 5 && propertyIds.includes(117)) {
+                cb(new Error('unknown property units'));
+                return;
+            }
+            cb(null, buildFullObjectResponse(request.objectId, `Object ${request.objectId.instance}`));
+        });
+
+        const { BacnetClient } = require('../src/bacnet_client');
+        const client = new BacnetClient({ runtimeState, bacnetConfig });
+        await client.ready;
+
+        const objects = await client.scanDevice({ address: '10.0.0.1', deviceId: 123 });
+
+        expect(objects.map((object) => object.objectId)).toEqual(allObjects);
+        expect(mockReadPropertyMultiple).toHaveBeenCalledWith(
+            '10.0.0.1',
+            [expect.objectContaining({
+                objectId: { type: 5, instance: 136448 },
+                properties: expect.not.arrayContaining([{ id: 117 }])
+            })],
+            expect.any(Object),
+            expect.any(Function)
+        );
+        cleanup(client);
+    });
+
     test('pollDevice emits telemetry with freshness metadata and persists state', async () => {
         mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
             const objectId = requestArray[0].objectId;
@@ -485,7 +526,7 @@ describe('BacnetClient', () => {
             values: [{ values: [{ value: [{ value: { type: 2, instance: 1 } }] }] }]
         }));
         jest.spyOn(client, '_readObjectListCount').mockResolvedValue(1);
-        jest.spyOn(client, '_readObjectFull').mockRejectedValue(new Error('catastrophic read'));
+        jest.spyOn(client, '_readObjectDiscoveryDetails').mockRejectedValue(new Error('catastrophic read'));
 
         await expect(client.scanDevice({ address: '10.0.0.5', deviceId: 5 })).rejects.toThrow('catastrophic read');
         expect(logger.log).toHaveBeenCalledWith('error', expect.stringContaining('catastrophic read'));

--- a/__tests__/bacnet_client.test.js
+++ b/__tests__/bacnet_client.test.js
@@ -253,6 +253,35 @@ describe('BacnetClient', () => {
         cleanup(client);
     });
 
+    test('scanDevice retries transient object list failures', async () => {
+        const objectId = { type: 2, instance: 202 };
+        mockReadProperty.mockImplementation((_addr, _objectId, _propertyId, options, cb) => {
+            cb(null, buildReadPropertyResponse(1, options.arrayIndex));
+        });
+        mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
+            const request = requestArray[0];
+            if (request.objectId.type === 8) {
+                if (mockReadPropertyMultiple.mock.calls.length === 1) {
+                    cb(new Error('temporary timeout'));
+                    return;
+                }
+                cb(null, buildObjectListResponse([objectId]));
+                return;
+            }
+            cb(null, buildFullObjectResponse(request.objectId, 'Zone Temp'));
+        });
+
+        const { BacnetClient } = require('../src/bacnet_client');
+        const client = new BacnetClient({ runtimeState, bacnetConfig });
+        await client.ready;
+
+        const objects = await client.scanDevice({ address: '10.0.0.1', deviceId: 123 });
+
+        expect(objects.map((object) => object.objectId)).toEqual([objectId]);
+        expect(mockReadPropertyMultiple).toHaveBeenCalledTimes(3);
+        cleanup(client);
+    });
+
     test('scanDevice keeps objects when optional full metadata reads fail', async () => {
         const allObjects = [
             { type: 5, instance: 136448 },
@@ -291,6 +320,36 @@ describe('BacnetClient', () => {
             expect.any(Object),
             expect.any(Function)
         );
+        cleanup(client);
+    });
+
+    test('scanDevice retries transient object metadata failures', async () => {
+        const objectId = { type: 5, instance: 136448 };
+        mockReadProperty.mockImplementation((_addr, _objectId, _propertyId, options, cb) => {
+            cb(null, buildReadPropertyResponse(1, options.arrayIndex));
+        });
+        mockReadPropertyMultiple.mockImplementation((_addr, requestArray, _opts, cb) => {
+            const request = requestArray[0];
+            if (request.objectId.type === 8) {
+                cb(null, buildObjectListResponse([objectId]));
+                return;
+            }
+            const fullReadCalls = mockReadPropertyMultiple.mock.calls.filter((call) => call[1][0].objectId.type === 5);
+            if (fullReadCalls.length === 1) {
+                cb(new Error('temporary object timeout'));
+                return;
+            }
+            cb(null, buildFullObjectResponse(request.objectId, 'Indoor On Off'));
+        });
+
+        const { BacnetClient } = require('../src/bacnet_client');
+        const client = new BacnetClient({ runtimeState, bacnetConfig });
+        await client.ready;
+
+        const objects = await client.scanDevice({ address: '10.0.0.1', deviceId: 123 });
+
+        expect(objects).toHaveLength(1);
+        expect(objects[0]).toMatchObject({ objectId, name: 'Indoor On Off' });
         cleanup(client);
     });
 

--- a/src/bacnet_client.js
+++ b/src/bacnet_client.js
@@ -393,6 +393,40 @@ class BacnetClient extends EventEmitter {
         this.client.readPropertyMultiple(deviceAddress, requestArray, this._buildRequestOptions(), callback);
     }
 
+    _readObjectListArrayIndex(deviceAddress, deviceId, arrayIndex) {
+        return new Promise((resolve, reject) => {
+            const objectId = { type: bacnet.enum.ObjectTypes.OBJECT_DEVICE, instance: deviceId };
+            const options = this._buildRequestOptions();
+            options.arrayIndex = arrayIndex;
+            this.client.readProperty(deviceAddress, objectId, bacnet.enum.PropertyIds.PROP_OBJECT_LIST, options, (error, value) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(value);
+                }
+            });
+        });
+    }
+
+    async _readObjectListCount(deviceAddress, deviceId) {
+        const value = await this._readObjectListArrayIndex(deviceAddress, deviceId, 0);
+        return this._extractObjectListCount(value);
+    }
+
+    async _readObjectListByIndex(deviceAddress, deviceId, count) {
+        const indexes = Array.from({ length: count }, (_item, idx) => idx + 1);
+        const reads = await this._runWithConcurrency(indexes, this.objectConcurrency, async (arrayIndex) => {
+            const value = await this._readObjectListArrayIndex(deviceAddress, deviceId, arrayIndex);
+            return this._extractIndexedObjectListEntry(value);
+        });
+        const objects = reads.map((entry) => entry && entry.result ? entry.result : entry);
+        if (objects.some((object) => !object || object.error)) {
+            const failed = objects.find((object) => object && object.error);
+            throw failed.error || new Error('Failed to read complete BACnet object list by index');
+        }
+        return this._dedupeObjectIds(objects);
+    }
+
     _readObject(deviceAddress, type, instance, properties) {
         return new Promise((resolve) => {
             const requestArray = [{
@@ -436,6 +470,69 @@ class BacnetClient extends EventEmitter {
         return null;
     }
 
+    _extractObjectListEntries(result) {
+        if (!result || !result.values || !result.values[0] || !result.values[0].values || !result.values[0].values[0]) {
+            return [];
+        }
+        const values = result.values[0].values[0].value;
+        if (!Array.isArray(values)) {
+            return [];
+        }
+        return this._dedupeObjectIds(values
+            .map((entry) => this._normalizeObjectIdentifierValue(entry))
+            .filter(Boolean));
+    }
+
+    _extractObjectListCount(result) {
+        if (!result || !Array.isArray(result.values) || !result.values[0]) {
+            return null;
+        }
+        const count = parseInt(result.values[0].value, 10);
+        return Number.isFinite(count) && count >= 0 ? count : null;
+    }
+
+    _extractIndexedObjectListEntry(result) {
+        if (!result || !Array.isArray(result.values) || !result.values[0]) {
+            return null;
+        }
+        return this._normalizeObjectIdentifierValue(result.values[0]);
+    }
+
+    _normalizeObjectIdentifierValue(entry) {
+        if (!entry) {
+            return null;
+        }
+        const value = entry.value !== undefined ? entry.value : entry;
+        if (value && value.type !== undefined && value.instance !== undefined) {
+            return {
+                type: parseInt(value.type, 10),
+                instance: parseInt(value.instance, 10)
+            };
+        }
+        if (value && value.objectId && value.objectId.type !== undefined && value.objectId.instance !== undefined) {
+            return {
+                type: parseInt(value.objectId.type, 10),
+                instance: parseInt(value.objectId.instance, 10)
+            };
+        }
+        return null;
+    }
+
+    _dedupeObjectIds(objects) {
+        const seen = new Set();
+        return objects.filter((object) => {
+            if (!object || Number.isNaN(object.type) || Number.isNaN(object.instance)) {
+                return false;
+            }
+            const key = `${object.type}_${object.instance}`;
+            if (seen.has(key)) {
+                return false;
+            }
+            seen.add(key);
+            return true;
+        });
+    }
+
     _mapToDeviceObject(object) {
         if (!object || !object.values) {
             return null;
@@ -466,22 +563,32 @@ class BacnetClient extends EventEmitter {
                     reject(err);
                     return;
                 }
-                const objectArray = result.values[0].values[0].value;
-                const promises = [];
-
-                objectArray.forEach((object) => {
-                    promises.push(this._readObjectFull(device.address, object.value.type, object.value.instance));
-                });
-
-                Promise.all(promises).then((resolved) => {
-                    const successfulResults = resolved.filter((element) => !element.error);
-                    const deviceObjects = successfulResults.map((element) => this._mapToDeviceObject(element.value));
-                    this.emit('deviceObjects', device, deviceObjects);
-                    resolve(deviceObjects);
-                }).catch((error) => {
-                    logger.log('error', `Error whilte fetching objects: ${error}`);
-                    reject(error);
-                });
+                Promise.resolve()
+                    .then(async () => {
+                        let objectArray = this._extractObjectListEntries(result);
+                        let expectedCount = null;
+                        try {
+                            expectedCount = await this._readObjectListCount(device.address, device.deviceId);
+                        } catch (countError) {
+                            logger.log('warn', `[Discovery] Failed to read Object_List count for ${device.deviceId}: ${countError.message || countError}`);
+                        }
+                        if (expectedCount !== null && objectArray.length !== expectedCount) {
+                            logger.log('warn', `[Discovery] Full Object_List returned ${objectArray.length}/${expectedCount} objects for ${device.deviceId}; retrying with indexed reads.`);
+                            objectArray = await this._readObjectListByIndex(device.address, device.deviceId, expectedCount);
+                        }
+                        return Promise.all(objectArray.map((object) => {
+                            return this._readObjectFull(device.address, object.type, object.instance);
+                        }));
+                    })
+                    .then((resolved) => {
+                        const successfulResults = resolved.filter((element) => !element.error);
+                        const deviceObjects = successfulResults.map((element) => this._mapToDeviceObject(element.value));
+                        this.emit('deviceObjects', device, deviceObjects);
+                        resolve(deviceObjects);
+                    }).catch((error) => {
+                        logger.log('error', `Error whilte fetching objects: ${error}`);
+                        reject(error);
+                    });
             });
         });
     }

--- a/src/bacnet_client.js
+++ b/src/bacnet_client.js
@@ -453,6 +453,34 @@ class BacnetClient extends EventEmitter {
         ]);
     }
 
+    _readObjectBasic(deviceAddress, type, instance) {
+        return this._readObject(deviceAddress, type, instance, [
+            { id: bacnet.enum.PropertyIds.PROP_OBJECT_IDENTIFIER },
+            { id: bacnet.enum.PropertyIds.PROP_OBJECT_NAME },
+            { id: bacnet.enum.PropertyIds.PROP_OBJECT_TYPE },
+            { id: bacnet.enum.PropertyIds.PROP_PRESENT_VALUE }
+        ]);
+    }
+
+    async _readObjectDiscoveryDetails(deviceAddress, objectId) {
+        const full = await this._readObjectFull(deviceAddress, objectId.type, objectId.instance);
+        if (!full.error) {
+            return full;
+        }
+
+        logger.log('warn', `[Discovery] Full object read failed for ${objectId.type}/${objectId.instance}: ${full.error.message || full.error}`);
+        const basic = await this._readObjectBasic(deviceAddress, objectId.type, objectId.instance);
+        if (!basic.error) {
+            return basic;
+        }
+
+        logger.log('warn', `[Discovery] Basic object read failed for ${objectId.type}/${objectId.instance}: ${basic.error.message || basic.error}`);
+        return {
+            error: null,
+            value: this._buildMinimalObjectReadResult(objectId)
+        };
+    }
+
     _readObjectPresentValue(deviceAddress, type, instance) {
         return this._readObject(deviceAddress, type, instance, [
             { id: bacnet.enum.PropertyIds.PROP_PRESENT_VALUE },
@@ -468,6 +496,18 @@ class BacnetClient extends EventEmitter {
             return property.value[0].value;
         }
         return null;
+    }
+
+    _buildMinimalObjectReadResult(objectId) {
+        return {
+            values: [{
+                objectId,
+                values: [
+                    { id: bacnet.enum.PropertyIds.PROP_OBJECT_IDENTIFIER, value: [{ value: objectId }] },
+                    { id: bacnet.enum.PropertyIds.PROP_OBJECT_TYPE, value: [{ value: objectId.type }] }
+                ]
+            }]
+        };
     }
 
     _extractObjectListEntries(result) {
@@ -577,7 +617,7 @@ class BacnetClient extends EventEmitter {
                             objectArray = await this._readObjectListByIndex(device.address, device.deviceId, expectedCount);
                         }
                         return Promise.all(objectArray.map((object) => {
-                            return this._readObjectFull(device.address, object.type, object.instance);
+                            return this._readObjectDiscoveryDetails(device.address, object);
                         }));
                     })
                     .then((resolved) => {

--- a/src/bacnet_client.js
+++ b/src/bacnet_client.js
@@ -26,6 +26,7 @@ class BacnetClient extends EventEmitter {
         this.failureThreshold = parseInt(pollingConfig.failureThreshold || 3, 10);
         this.baseBackoffMs = parseInt(pollingConfig.baseBackoffMs || 5000, 10);
         this.maxBackoffMs = parseInt(pollingConfig.maxBackoffMs || 120000, 10);
+        this.discoveryRetries = this._loadIntegerOption('bacnet.discoveryRetries', 2);
 
         this.metrics = {
             totalPolls: 0,
@@ -88,6 +89,14 @@ class BacnetClient extends EventEmitter {
             options.priority = priority;
         }
         return options;
+    }
+
+    _loadIntegerOption(path, fallback) {
+        if (!config.has(path)) {
+            return fallback;
+        }
+        const value = parseInt(config.get(path), 10);
+        return Number.isNaN(value) ? fallback : value;
     }
 
     async _registerDeviceConfig(deviceConfig) {
@@ -393,6 +402,25 @@ class BacnetClient extends EventEmitter {
         this.client.readPropertyMultiple(deviceAddress, requestArray, this._buildRequestOptions(), callback);
     }
 
+    _readObjectListOnce(deviceAddress, deviceId) {
+        return new Promise((resolve, reject) => {
+            this._readObjectList(deviceAddress, deviceId, (error, value) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(value);
+                }
+            });
+        });
+    }
+
+    async _readObjectListWithRetry(deviceAddress, deviceId) {
+        return this._retryDiscoveryRead(
+            () => this._readObjectListOnce(deviceAddress, deviceId),
+            `Object_List for ${deviceId}`
+        );
+    }
+
     _readObjectListArrayIndex(deviceAddress, deviceId, arrayIndex) {
         return new Promise((resolve, reject) => {
             const objectId = { type: bacnet.enum.ObjectTypes.OBJECT_DEVICE, instance: deviceId };
@@ -408,15 +436,22 @@ class BacnetClient extends EventEmitter {
         });
     }
 
+    async _readObjectListArrayIndexWithRetry(deviceAddress, deviceId, arrayIndex) {
+        return this._retryDiscoveryRead(
+            () => this._readObjectListArrayIndex(deviceAddress, deviceId, arrayIndex),
+            `Object_List[${arrayIndex}] for ${deviceId}`
+        );
+    }
+
     async _readObjectListCount(deviceAddress, deviceId) {
-        const value = await this._readObjectListArrayIndex(deviceAddress, deviceId, 0);
+        const value = await this._readObjectListArrayIndexWithRetry(deviceAddress, deviceId, 0);
         return this._extractObjectListCount(value);
     }
 
     async _readObjectListByIndex(deviceAddress, deviceId, count) {
         const indexes = Array.from({ length: count }, (_item, idx) => idx + 1);
         const reads = await this._runWithConcurrency(indexes, this.objectConcurrency, async (arrayIndex) => {
-            const value = await this._readObjectListArrayIndex(deviceAddress, deviceId, arrayIndex);
+            const value = await this._readObjectListArrayIndexWithRetry(deviceAddress, deviceId, arrayIndex);
             return this._extractIndexedObjectListEntry(value);
         });
         const objects = reads.map((entry) => entry && entry.result ? entry.result : entry);
@@ -425,6 +460,21 @@ class BacnetClient extends EventEmitter {
             throw failed.error || new Error('Failed to read complete BACnet object list by index');
         }
         return this._dedupeObjectIds(objects);
+    }
+
+    async _retryDiscoveryRead(readFn, label) {
+        let lastError = null;
+        for (let attempt = 0; attempt <= this.discoveryRetries; attempt += 1) {
+            try {
+                return await readFn();
+            } catch (error) {
+                lastError = error;
+                if (attempt < this.discoveryRetries) {
+                    logger.log('warn', `[Discovery] ${label} failed on attempt ${attempt + 1}/${this.discoveryRetries + 1}: ${error.message || error}`);
+                }
+            }
+        }
+        throw lastError;
     }
 
     _readObject(deviceAddress, type, instance, properties) {
@@ -453,6 +503,21 @@ class BacnetClient extends EventEmitter {
         ]);
     }
 
+    async _readObjectWithRetry(deviceAddress, type, instance, properties, label) {
+        let lastResult = null;
+        for (let attempt = 0; attempt <= this.discoveryRetries; attempt += 1) {
+            const result = await this._readObject(deviceAddress, type, instance, properties);
+            if (!result.error) {
+                return result;
+            }
+            lastResult = result;
+            if (attempt < this.discoveryRetries) {
+                logger.log('warn', `[Discovery] ${label} failed on attempt ${attempt + 1}/${this.discoveryRetries + 1}: ${result.error.message || result.error}`);
+            }
+        }
+        return lastResult;
+    }
+
     _readObjectBasic(deviceAddress, type, instance) {
         return this._readObject(deviceAddress, type, instance, [
             { id: bacnet.enum.PropertyIds.PROP_OBJECT_IDENTIFIER },
@@ -463,13 +528,37 @@ class BacnetClient extends EventEmitter {
     }
 
     async _readObjectDiscoveryDetails(deviceAddress, objectId) {
-        const full = await this._readObjectFull(deviceAddress, objectId.type, objectId.instance);
+        const full = await this._readObjectWithRetry(
+            deviceAddress,
+            objectId.type,
+            objectId.instance,
+            [
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_IDENTIFIER },
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_NAME },
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_TYPE },
+                { id: bacnet.enum.PropertyIds.PROP_DESCRIPTION },
+                { id: bacnet.enum.PropertyIds.PROP_UNITS },
+                { id: bacnet.enum.PropertyIds.PROP_PRESENT_VALUE }
+            ],
+            `full metadata ${objectId.type}/${objectId.instance}`
+        );
         if (!full.error) {
             return full;
         }
 
         logger.log('warn', `[Discovery] Full object read failed for ${objectId.type}/${objectId.instance}: ${full.error.message || full.error}`);
-        const basic = await this._readObjectBasic(deviceAddress, objectId.type, objectId.instance);
+        const basic = await this._readObjectWithRetry(
+            deviceAddress,
+            objectId.type,
+            objectId.instance,
+            [
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_IDENTIFIER },
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_NAME },
+                { id: bacnet.enum.PropertyIds.PROP_OBJECT_TYPE },
+                { id: bacnet.enum.PropertyIds.PROP_PRESENT_VALUE }
+            ],
+            `basic metadata ${objectId.type}/${objectId.instance}`
+        );
         if (!basic.error) {
             return basic;
         }
@@ -596,41 +685,34 @@ class BacnetClient extends EventEmitter {
     }
 
     scanDevice(device) {
-        return new Promise((resolve, reject) => {
-            this._readObjectList(device.address, device.deviceId, (err, result) => {
-                if (err) {
-                    logger.log('error', `Error whilte fetching objects: ${err}`);
-                    reject(err);
-                    return;
-                }
-                Promise.resolve()
-                    .then(async () => {
-                        let objectArray = this._extractObjectListEntries(result);
-                        let expectedCount = null;
-                        try {
-                            expectedCount = await this._readObjectListCount(device.address, device.deviceId);
-                        } catch (countError) {
-                            logger.log('warn', `[Discovery] Failed to read Object_List count for ${device.deviceId}: ${countError.message || countError}`);
-                        }
-                        if (expectedCount !== null && objectArray.length !== expectedCount) {
-                            logger.log('warn', `[Discovery] Full Object_List returned ${objectArray.length}/${expectedCount} objects for ${device.deviceId}; retrying with indexed reads.`);
-                            objectArray = await this._readObjectListByIndex(device.address, device.deviceId, expectedCount);
-                        }
-                        return Promise.all(objectArray.map((object) => {
-                            return this._readObjectDiscoveryDetails(device.address, object);
-                        }));
-                    })
-                    .then((resolved) => {
-                        const successfulResults = resolved.filter((element) => !element.error);
-                        const deviceObjects = successfulResults.map((element) => this._mapToDeviceObject(element.value));
-                        this.emit('deviceObjects', device, deviceObjects);
-                        resolve(deviceObjects);
-                    }).catch((error) => {
-                        logger.log('error', `Error whilte fetching objects: ${error}`);
-                        reject(error);
-                    });
-            });
-        });
+        return this._scanDevice(device);
+    }
+
+    async _scanDevice(device) {
+        try {
+            const result = await this._readObjectListWithRetry(device.address, device.deviceId);
+            let objectArray = this._extractObjectListEntries(result);
+            let expectedCount = null;
+            try {
+                expectedCount = await this._readObjectListCount(device.address, device.deviceId);
+            } catch (countError) {
+                logger.log('warn', `[Discovery] Failed to read Object_List count for ${device.deviceId}: ${countError.message || countError}`);
+            }
+            if (expectedCount !== null && objectArray.length !== expectedCount) {
+                logger.log('warn', `[Discovery] Full Object_List returned ${objectArray.length}/${expectedCount} objects for ${device.deviceId}; retrying with indexed reads.`);
+                objectArray = await this._readObjectListByIndex(device.address, device.deviceId, expectedCount);
+            }
+            const resolved = await Promise.all(objectArray.map((object) => {
+                return this._readObjectDiscoveryDetails(device.address, object);
+            }));
+            const successfulResults = resolved.filter((element) => !element.error);
+            const deviceObjects = successfulResults.map((element) => this._mapToDeviceObject(element.value));
+            this.emit('deviceObjects', device, deviceObjects);
+            return deviceObjects;
+        } catch (error) {
+            logger.log('error', `Error whilte fetching objects: ${error}`);
+            throw error;
+        }
     }
 
     startPolling(device, objects, pollingOrSchedule) {


### PR DESCRIPTION
## Summary

- Harden BACnet object discovery for large and unreliable Object_List responses.
- Verify Object_List size and fall back to indexed Object_List reads when the full response is incomplete.
- Retry transient discovery reads and keep valid objects when optional metadata reads fail.

## Tests

- `npm test -- --runInBand`
- @dzwigar tested in his setup (#50 )