### PR TITLE
chore: add Dependabot version updates config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot version updates. Low-risk bumps are auto-approved and
+# merged by our chore bot (PaxMachinaOne) once checks are green.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds Dependabot version updates (weekly) for the ecosystems in this repo. Low-risk bumps get auto-approved and squash-merged by our chore bot once checks are green; anything outside the manifest allowlist is left for human review.